### PR TITLE
Auth correct email note

### DIFF
--- a/doc/source/gettingstarted.rst
+++ b/doc/source/gettingstarted.rst
@@ -56,7 +56,7 @@ First, make your araalictl executable::
 
 Authorize your session::
 
-   sudo ./araalictl authorize
+   sudo ./araalictl authorize <CORRECT EMAIL ADDRESS>
 
    **NOTE: To correctly authorize araalictl, please enter the correct and same email used when creating an account in Araali Console.**
 

--- a/doc/source/gettingstarted.rst
+++ b/doc/source/gettingstarted.rst
@@ -58,6 +58,8 @@ Authorize your session::
 
    sudo ./araalictl authorize
 
+   **NOTE: To correctly authorize araalictl, please enter the correct and same email used when creating an account in Araali Console.**
+
 .. image:: https://publicimageproduct.s3-us-west-2.amazonaws.com/AraalictlAuthorize.png
   :width: 650
   :alt: Araalictl authorize


### PR DESCRIPTION
Created a note for the user to enter the correct and same email as the one used when signing up in the Araali Console.