### PR TITLE
New test cases are added for validating the ListAlerts API with Zone filter

### DIFF
--- a/golang/v2/test/api_test.go
+++ b/golang/v2/test/api_test.go
@@ -52,7 +52,7 @@ func TestAlerts(t *testing.T) {
 }
 
 //Testing ListAlerts with specific Zone passed. Return only those zone specific alerts
-func TestAlertsZoneFilter(t *testing.T) {
+func TestAlertsFilterValidZone(t *testing.T) {
 	setup(t)
 
 	zone := "nightlycommon"
@@ -97,15 +97,15 @@ func TestAlertsZoneFilter(t *testing.T) {
 }
 
 //Testing ListAlerts with specific Zone passed which returns ZERO count
-func TestAlertsZoneFilterNoResults(t *testing.T) {
+func TestAlertsFilterInvalidZone(t *testing.T) {
 	setup(t)
 
-	zone := "intern-nightly"
+	zone := "invalidzone"
 	tenantID := "meta-tap"
 	filter := araali_api_service.AlertFilter{
 		Time: &araali_api_service.TimeSlice{
-			StartTime: timestamppb.New(time.Date(2022, time.July, 25, 3, 8, 0, 0, time.UTC)),
-			EndTime:   timestamppb.New(time.Date(2022, time.July, 25, 3, 9, 0, 0, time.UTC)),
+			StartTime: timestamppb.New(time.Date(1980, time.November, 0, 0, 0, 0, 0, time.UTC)),
+			EndTime:   timestamppb.New(time.Now()),
 		},
 		ListAllAlerts:        false,
 		OpenAlerts:           true,

--- a/golang/v2/test/api_test.go
+++ b/golang/v2/test/api_test.go
@@ -50,3 +50,78 @@ func TestAlerts(t *testing.T) {
 		t.Fatalf("ListAlerts() = %v, want 10", len(resp.Alerts))
 	}
 }
+
+//Testing ListAlerts with specific Zone passed. Return only those zone specific alerts
+func TestAlertsZoneFilter(t *testing.T) {
+	setup(t)
+
+	zone := "nightlycommon"
+	tenantID := "meta-tap"
+	filter := araali_api_service.AlertFilter{
+		Time: &araali_api_service.TimeSlice{
+			StartTime: timestamppb.New(time.Date(1980, time.November, 0, 0, 0, 0, 0, time.UTC)),
+			EndTime:   timestamppb.New(time.Now()),
+		},
+		ListAllAlerts:        false,
+		OpenAlerts:           true,
+		ClosedAlerts:         false,
+		PerimeterIngress:     true,
+		PerimeterEgress:      true,
+		HomeNonAraaliIngress: true,
+		HomeNonAraaliEgress:  true,
+		AraaliToAraali:       true,
+		Zone:                 zone,
+	}
+	resp, err := api.ListAlerts(tenantID, &filter, 10, "")
+	totalAlerts := len(resp.Alerts)
+
+	if verbose > 0 {
+		fmt.Printf("\nR: %+v/%v\n", totalAlerts, err)
+	}
+
+	counter := 0
+	for _, s := range resp.Alerts {
+		_, araaliEndpoint := s.Client.Info.(*araali_api_service.EndPoint_Araali)
+		if araaliEndpoint {
+			if s.Client.GetAraali().Zone == zone {
+				counter++
+			}
+		}
+	}
+
+	//Validate whether all the alerts are corresponding to passed zone value
+	if counter != totalAlerts {
+		t.Fatalf("%v count in the response = %v, want %v", zone, counter, totalAlerts)
+	}
+
+}
+
+//Testing ListAlerts with specific Zone passed which returns ZERO count
+func TestAlertsZoneFilterNoResults(t *testing.T) {
+	setup(t)
+
+	zone := "intern-nightly"
+	tenantID := "meta-tap"
+	filter := araali_api_service.AlertFilter{
+		Time: &araali_api_service.TimeSlice{
+			StartTime: timestamppb.New(time.Date(2022, time.July, 25, 3, 8, 0, 0, time.UTC)),
+			EndTime:   timestamppb.New(time.Date(2022, time.July, 25, 3, 9, 0, 0, time.UTC)),
+		},
+		ListAllAlerts:        false,
+		OpenAlerts:           true,
+		ClosedAlerts:         false,
+		PerimeterIngress:     true,
+		PerimeterEgress:      true,
+		HomeNonAraaliIngress: true,
+		HomeNonAraaliEgress:  true,
+		AraaliToAraali:       true,
+		Zone:                 zone,
+	}
+	resp, err := api.ListAlerts(tenantID, &filter, 10, "")
+	if verbose > 0 {
+		fmt.Printf("\nR: %+v/%v\n", len(resp.Alerts), err)
+	}
+	if len(resp.Alerts) != 0 {
+		t.Fatalf("ListAlerts() = %v, want 0", len(resp.Alerts))
+	}
+}


### PR DESCRIPTION
ListAlerts API has been enhanced to accept the zone to filter out the alerts. For this new enhancement, new test cases has been added to validate the functionality

Test case 1: zone filter is included in the request and expecting the results
Test case2: zone filter is included in the request and expected ZERO results.